### PR TITLE
fix(formOptions): errors caused by formOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
-    "@data-driven-forms/react-form-renderer": "^1.9.3",
+    "@data-driven-forms/react-form-renderer": "^1.9.6",
     "@patternfly/react-core": "^1.51.6",
     "@patternfly/react-icons": "^2.8.0",
     "@semantic-release/git": "^7.0.5",
@@ -107,7 +107,7 @@
     ]
   },
   "peerDependencies": {
-    "@data-driven-forms/react-form-renderer": "^1.9.3",
+    "@data-driven-forms/react-form-renderer": "^1.9.6",
     "@patternfly/react-core": "^1.51.6",
     "@patternfly/react-icons": "^2.8.0"
   },

--- a/src/form-fields/form-fields.js
+++ b/src/form-fields/form-fields.js
@@ -26,6 +26,9 @@ const selectComponent = ({
   isVisible,
   onText,
   offText,
+  formOptions,
+  assignFieldProvider,
+  initialValue,
   ...rest
 }) => ({
   [componentTypes.TEXT_FIELD]: () => (
@@ -61,7 +64,7 @@ const selectComponent = ({
     />
   )),
   [componentTypes.SWITCH]: () => {
-    const { formOptions, isValid, ...newRest } = rest;
+    const { isValid, ...newRest } = rest;
     return <Switch
       { ...newRest }
       { ...input }

--- a/src/form-fields/multiple-choice-list.js
+++ b/src/form-fields/multiple-choice-list.js
@@ -29,7 +29,7 @@ const MultipleChoiceList = ({ validate, FieldProvider, ...props }) => (
         <FormGroup label={ label } fieldId={ rest.id || rest.key || rest.name } isValid={ showError } >
           { options.map(option =>
             (<FieldProvider
-              {...rest}
+              formOptions={rest.formOptions}
               id={ `${rest.id}-${option.value}` }
               key={ option.value }
               { ...option }

--- a/src/tests/__snapshots__/form-fields.test.js.snap
+++ b/src/tests/__snapshots__/form-fields.test.js.snap
@@ -249,20 +249,12 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
               className="pf-c-form__group"
             >
               <FieldProvider
-                componentType="checkbox"
                 id="someIdKey-1"
-                input={
-                  Object {
-                    "name": "Name of the field",
-                    "value": "",
-                  }
-                }
                 key="1"
                 label="One"
                 name="Name of the field"
                 render={[Function]}
                 type="checkbox"
-                validate={[Function]}
                 value="1"
               >
                 <div>
@@ -277,7 +269,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
                     name="Name of the field"
                     onChange={[Function]}
                     type="checkbox"
-                    validate={[Function]}
                     value="1"
                   >
                     <div
@@ -292,7 +283,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
                         name="Name of the field"
                         onChange={[Function]}
                         type="checkbox"
-                        validate={[Function]}
                         value="1"
                       />
                       <label
@@ -306,20 +296,12 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
                 </div>
               </FieldProvider>
               <FieldProvider
-                componentType="checkbox"
                 id="someIdKey-2"
-                input={
-                  Object {
-                    "name": "Name of the field",
-                    "value": "",
-                  }
-                }
                 key="2"
                 label="Two"
                 name="Name of the field"
                 render={[Function]}
                 type="checkbox"
-                validate={[Function]}
                 value="2"
               >
                 <div>
@@ -334,7 +316,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
                     name="Name of the field"
                     onChange={[Function]}
                     type="checkbox"
-                    validate={[Function]}
                     value="2"
                   >
                     <div
@@ -349,7 +330,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
                         name="Name of the field"
                         onChange={[Function]}
                         type="checkbox"
-                        validate={[Function]}
                         value="2"
                       />
                       <label
@@ -363,20 +343,12 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
                 </div>
               </FieldProvider>
               <FieldProvider
-                componentType="checkbox"
                 id="someIdKey-3"
-                input={
-                  Object {
-                    "name": "Name of the field",
-                    "value": "",
-                  }
-                }
                 key="3"
                 label="Three"
                 name="Name of the field"
                 render={[Function]}
                 type="checkbox"
-                validate={[Function]}
                 value="3"
               >
                 <div>
@@ -391,7 +363,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
                     name="Name of the field"
                     onChange={[Function]}
                     type="checkbox"
-                    validate={[Function]}
                     value="3"
                   >
                     <div
@@ -406,7 +377,6 @@ exports[`FormFields should render Checkbox with options correctly 1`] = `
                         name="Name of the field"
                         onChange={[Function]}
                         type="checkbox"
-                        validate={[Function]}
                         value="3"
                       />
                       <label
@@ -1550,28 +1520,18 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
               className="pf-c-form__group"
             >
               <FieldProvider
-                componentType="checkbox"
-                disabled={true}
                 id="someIdKey-1"
-                input={
-                  Object {
-                    "name": "Name of the field",
-                    "value": "",
-                  }
-                }
                 key="1"
                 label="One"
                 name="Name of the field"
                 render={[Function]}
                 type="checkbox"
-                validate={[Function]}
                 value="1"
               >
                 <div>
                   <Checkbox
                     aria-label="One"
                     className=""
-                    disabled={true}
                     id="someIdKey-1"
                     isChecked={null}
                     isDisabled={false}
@@ -1580,7 +1540,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
                     name="Name of the field"
                     onChange={[Function]}
                     type="checkbox"
-                    validate={[Function]}
                     value="1"
                   >
                     <div
@@ -1595,7 +1554,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
                         name="Name of the field"
                         onChange={[Function]}
                         type="checkbox"
-                        validate={[Function]}
                         value="1"
                       />
                       <label
@@ -1609,28 +1567,18 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
                 </div>
               </FieldProvider>
               <FieldProvider
-                componentType="checkbox"
-                disabled={true}
                 id="someIdKey-2"
-                input={
-                  Object {
-                    "name": "Name of the field",
-                    "value": "",
-                  }
-                }
                 key="2"
                 label="Two"
                 name="Name of the field"
                 render={[Function]}
                 type="checkbox"
-                validate={[Function]}
                 value="2"
               >
                 <div>
                   <Checkbox
                     aria-label="Two"
                     className=""
-                    disabled={true}
                     id="someIdKey-2"
                     isChecked={null}
                     isDisabled={false}
@@ -1639,7 +1587,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
                     name="Name of the field"
                     onChange={[Function]}
                     type="checkbox"
-                    validate={[Function]}
                     value="2"
                   >
                     <div
@@ -1654,7 +1601,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
                         name="Name of the field"
                         onChange={[Function]}
                         type="checkbox"
-                        validate={[Function]}
                         value="2"
                       />
                       <label
@@ -1668,28 +1614,18 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
                 </div>
               </FieldProvider>
               <FieldProvider
-                componentType="checkbox"
-                disabled={true}
                 id="someIdKey-3"
-                input={
-                  Object {
-                    "name": "Name of the field",
-                    "value": "",
-                  }
-                }
                 key="3"
                 label="Three"
                 name="Name of the field"
                 render={[Function]}
                 type="checkbox"
-                validate={[Function]}
                 value="3"
               >
                 <div>
                   <Checkbox
                     aria-label="Three"
                     className=""
-                    disabled={true}
                     id="someIdKey-3"
                     isChecked={null}
                     isDisabled={false}
@@ -1698,7 +1634,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
                     name="Name of the field"
                     onChange={[Function]}
                     type="checkbox"
-                    validate={[Function]}
                     value="3"
                   >
                     <div
@@ -1713,7 +1648,6 @@ exports[`FormFields should render disabled Checkbox with options correctly 1`] =
                         name="Name of the field"
                         onChange={[Function]}
                         type="checkbox"
-                        validate={[Function]}
                         value="3"
                       />
                       <label


### PR DESCRIPTION
We don't need to pass formOptions to any basic components, am I right?